### PR TITLE
feat: Display legacy services in order management

### DIFF
--- a/src/components/edit-order-components/AbstractOrderService.tsx
+++ b/src/components/edit-order-components/AbstractOrderService.tsx
@@ -22,7 +22,7 @@ export function AbstractOrderService({ tag }: Readonly<Props>) {
   const dispatch = useDispatch<AppDispatch>();
 
   const currentServiceIds = services?.map((s) => s.id) || [];
-  const legacyServices = order?.services?.filter((s) => !currentServiceIds.includes(s.id)).filter((s) => s.tag === tag);
+  const legacyServices = order?.services?.filter((s) => !currentServiceIds.includes(s.id) && s.tag === tag) || [];
 
   const getPreis = (serv: OrderService) => {
     const orderServ = order?.services?.find((s) => s.id === serv.id);
@@ -81,7 +81,7 @@ export function AbstractOrderService({ tag }: Readonly<Props>) {
         disablePagination
         onUpdate={onUpdate}
       />
-      {legacyServices?.length && legacyServices.length > 0 ? (
+      {legacyServices?.length > 0 ? (
         <>
           <Divider sx={{ my: 2 }} />
           <Typography variant="h6" color="primary">
@@ -90,7 +90,7 @@ export function AbstractOrderService({ tag }: Readonly<Props>) {
           <Typography color="textSecondary" variant="body2">
             keine Ausgabe auf PDF
           </Typography>
-          <AppDataGrid columns={columns} data={legacyServices || []} disablePagination onUpdate={onUpdate} />
+          <AppDataGrid columns={columns} data={legacyServices} disablePagination onUpdate={onUpdate} />
         </>
       ) : null}
     </Box>

--- a/src/components/edit-order-components/AbstractOrderService.tsx
+++ b/src/components/edit-order-components/AbstractOrderService.tsx
@@ -1,3 +1,4 @@
+import { Box, Divider, Typography } from '@mui/material';
 import { GridColDef } from '@mui/x-data-grid';
 
 import { useDispatch } from 'react-redux';
@@ -9,17 +10,19 @@ import { updateOrderService } from '../../store/appReducer';
 import { euroValue } from '../../utils/utils';
 import { AppDataGrid } from '../shared/AppDataGrid';
 
-import { AppServiceTag, OrderService } from '@umzug-meister/um-core';
+import { AppService, AppServiceTag, OrderService } from '@umzug-meister/um-core';
 
 interface Props {
   tag: AppServiceTag;
 }
 
 export function AbstractOrderService({ tag }: Readonly<Props>) {
-  const services = useAppServices(tag).sort((a: any, b: any) => (a.name as string).localeCompare(b.name));
+  const services = useAppServices<OrderService>(tag).sort((a: any, b: any) => (a.name as string).localeCompare(b.name));
   const order = useCurrentOrder();
-
   const dispatch = useDispatch<AppDispatch>();
+
+  const currentServiceIds = services?.map((s) => s.id) || [];
+  const legacyServices = order?.services?.filter((s) => !currentServiceIds.includes(s.id)).filter((s) => s.tag === tag);
 
   const getPreis = (serv: OrderService) => {
     const orderServ = order?.services?.find((s) => s.id === serv.id);
@@ -63,19 +66,33 @@ export function AbstractOrderService({ tag }: Readonly<Props>) {
   ];
 
   return (
-    <AppDataGrid
-      getRowClassName={({ row }) => {
-        const service = row as OrderService;
+    <Box>
+      <AppDataGrid
+        getRowClassName={({ row }) => {
+          const service = row as OrderService;
 
-        if (getColli(service) > 0) {
-          return 'bold';
-        }
-        return '';
-      }}
-      columns={columns}
-      data={services}
-      disablePagination
-      onUpdate={onUpdate}
-    />
+          if (getColli(service) > 0) {
+            return 'bold';
+          }
+          return '';
+        }}
+        columns={columns}
+        data={services}
+        disablePagination
+        onUpdate={onUpdate}
+      />
+      {legacyServices?.length && legacyServices.length > 0 ? (
+        <>
+          <Divider sx={{ my: 2 }} />
+          <Typography variant="h6" color="primary">
+            Nicht aktuelle Leistungen
+          </Typography>
+          <Typography color="textSecondary" variant="body2">
+            keine Ausgabe auf PDF
+          </Typography>
+          <AppDataGrid columns={columns} data={legacyServices || []} disablePagination onUpdate={onUpdate} />
+        </>
+      ) : null}
+    </Box>
   );
 }

--- a/src/components/edit-order-components/AbstractOrderService.tsx
+++ b/src/components/edit-order-components/AbstractOrderService.tsx
@@ -10,7 +10,7 @@ import { updateOrderService } from '../../store/appReducer';
 import { euroValue } from '../../utils/utils';
 import { AppDataGrid } from '../shared/AppDataGrid';
 
-import { AppService, AppServiceTag, OrderService } from '@umzug-meister/um-core';
+import { AppServiceTag, OrderService } from '@umzug-meister/um-core';
 
 interface Props {
   tag: AppServiceTag;


### PR DESCRIPTION
Introduce functionality to display legacy services alongside current services in the order management interface, enhancing visibility for users.